### PR TITLE
Update for api access docs

### DIFF
--- a/simulations-and-forks/simulation-api/configuration-of-api-access.md
+++ b/simulations-and-forks/simulation-api/configuration-of-api-access.md
@@ -38,7 +38,7 @@ export const anAxiosOnTenderly = () =>
 
 With Tenderly API you can either do operations that are related to your particular project or a specific Fork. In this case, you’ll also need to specify your project’s slug and the user: `TENDERLY_USER` and `TENDERLY_PROJECT`.&#x20;
 
-Note: For projects that are owned by an Organization the `TENDERLY_USER` will be the Organization name. The `TENDERLY_PROJECT` value DOES NOT include the organizational slug.
+Note: For projects that are owned by an Organization the `TENDERLY_USER` will be the Organization name slug. The `TENDERLY_PROJECT` value DOES NOT include the Organization name slug.
 
 You can extract it from the dashboard URL and place these in a safe place:
 

--- a/simulations-and-forks/simulation-api/configuration-of-api-access.md
+++ b/simulations-and-forks/simulation-api/configuration-of-api-access.md
@@ -38,6 +38,8 @@ export const anAxiosOnTenderly = () =>
 
 With Tenderly API you can either do operations that are related to your particular project or a specific Fork. In this case, you’ll also need to specify your project’s slug and the user: `TENDERLY_USER` and `TENDERLY_PROJECT`.&#x20;
 
+Note: For projects that are owned by an Organization the `TENDERLY_USER` will be the Organization name. The `TENDERLY_PROJECT` value DOES NOT include the organizational slug.
+
 You can extract it from the dashboard URL and place these in a safe place:
 
 `https://dashboard.tenderly.co/account/TENDERLY_USER/project/TENDERLY_PROJECT/`


### PR DESCRIPTION
The current docs have some ambiguity that lead to confusion on my team when we were trying to configure access to project owned by an organization.

The distinction between user and organization is not clear in the docs and lead to incorrect values and access issues.